### PR TITLE
Support VS2019 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@
 *.idb
 *.pdb
 *.pyc
+*~
+.p4config
+.vscode
+BRANCH_OWNERS
+omaha/*.idb
 omaha/common/omaha_customization_proxy_clsid.h
 omaha/proxy_clsids.txt
 omaha/scons-out/**

--- a/doc/DeveloperSetupGuide.md
+++ b/doc/DeveloperSetupGuide.md
@@ -6,11 +6,13 @@ We are striving to make the code build with the latest Windows toolchain from Mi
 
 #### Currently, the supported toolchain is Visual Studio 2017 Update 15.9.11 and Windows SDK 10.0.17763.0. ####
 
+But VS2019 should now work.
+
 # Required Downloads/Tools #
 
 The following packages are required to build Omaha:
   * A copy of the Omaha source code.  This can be done by cloning this repository.
-  * Microsoft Visual Studio 2017. The free Visual Studio Community edition is sufficient to build.
+  * Microsoft Visual Studio 2017 or 2019. The free Visual Studio Community edition is sufficient to build.
     * Download [here](https://visualstudio.microsoft.com/downloads)
   * ATL Server headers
     * Download [here](http://atlserver.codeplex.com). Omaha needs this library for regular expression support.

--- a/omaha/base/string.h
+++ b/omaha/base/string.h
@@ -17,6 +17,7 @@
 #define OMAHA_BASE_STRING_H_
 
 #include <windows.h>
+#include <string>
 #include <vector>
 #include "base/basictypes.h"
 #include "omaha/base/constants.h"

--- a/omaha/common/xml_parser.cc
+++ b/omaha/common/xml_parser.cc
@@ -14,6 +14,7 @@
 // ========================================================================
 
 #include "omaha/common/xml_parser.h"
+#include <memory>
 #include <stdlib.h>
 #include <vector>
 #include "base/basictypes.h"

--- a/omaha/hammer.bat
+++ b/omaha/hammer.bat
@@ -16,11 +16,13 @@ rem -- Set all environment variables used by Hammer and Omaha. --
 :: VS2013/VC12 is 1800.
 :: VS2015/VC14 is 1900.
 :: VS2017/VC14.1 is 1910.
+:: VS2019/VC16.0 is 1920.
 
 if "%VisualStudioVersion%"=="" goto error_no_vc
 if "%VisualStudioVersion%"=="12.0" goto vc120
 if "%VisualStudioVersion%"=="14.0" goto vc140
 if "%VisualStudioVersion%"=="15.0" goto vc141
+if "%VisualStudioVersion%"=="16.0" goto vc160
 goto error_vc_not_supported
 
 :vc120
@@ -33,6 +35,10 @@ goto set_env_variables
 
 :vc141
 set OMAHA_MSC_VER=1910
+goto set_env_variables
+
+:vc160
+set OMAHA_MSC_VER=1920
 goto set_env_variables
 
 :set_env_variables

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -101,15 +101,15 @@ _BUILD_SERVER_CERTIFICATE_HASH = 'CB7E84887F3C6015FE7EDFB4F8F36DF7DC10590E'
 # The set of expected values are in omaha_version_utils.
 # Defaults to VC140 if the environment variable is not specified.
 _msc_ver = int(os.getenv('OMAHA_MSC_VER', "1900"))
-
-_default_sdk_dir = ('$THIRD_PARTY/%s/files' %
-    {omaha_version_utils.VC141:'windows_sdk/windows_sdk_10',
+_sdk_dir = os.getenv('WindowsSdkDir', os.getenv('OMAHA_PLATFORM_SDK_DIR'))
+if (_sdk_dir is None):
+    _sdk_dir = ('$THIRD_PARTY/%s/files' %
+   { omaha_version_utils.VC160:'windows_sdk/windows_sdk_10',
+     omaha_version_utils.VC141:'windows_sdk/windows_sdk_10',
      omaha_version_utils.VC140:'windows_sdk/windows_sdk_10',
      omaha_version_utils.VC120:'windows_sdk_8_1',
      omaha_version_utils.VC100:'platformsdk_vc_10_0',
      omaha_version_utils.VC80:'platformsdk/v6_1' }[_msc_ver])
-
-_sdk_dir = os.getenv('OMAHA_PLATFORM_SDK_DIR', _default_sdk_dir)
 
 _sdk_version = os.getenv('OMAHA_WINDOWS_SDK_10_0_VERSION', None)
 
@@ -131,14 +131,16 @@ win_env = Environment(
     tools=[
         'component_setup',
         'target_platform_windows',
-        { omaha_version_utils.VC141:'windows_vc14_1',
+        { omaha_version_utils.VC160:'windows_vc16_0',
+          omaha_version_utils.VC141:'windows_vc14_1',
           omaha_version_utils.VC140:'windows_vc14_0',
           omaha_version_utils.VC120:'windows_vc12_0',
           omaha_version_utils.VC100:'windows_vc10_0',
           omaha_version_utils.VC80:'target_platform_windows' }[_msc_ver],
         'masm',         # Use 'masm' to override the 'as' tool currently
                         # used by default in 'target_platform_windows'
-        { omaha_version_utils.VC141:'atlmfc_vc14_1',
+        { omaha_version_utils.VC160:'atlmfc_vc16_0',
+          omaha_version_utils.VC141:'atlmfc_vc14_1',
           omaha_version_utils.VC140:'atlmfc_vc14_0',
           omaha_version_utils.VC120:'atlmfc_vc12_0',
           omaha_version_utils.VC100:'atlmfc_vc10_0',

--- a/omaha/omaha_version_utils.py
+++ b/omaha/omaha_version_utils.py
@@ -98,6 +98,7 @@ VC110 = 1700  # VC2012/VC11 (not supported by the current build).
 VC120 = 1800  # VC2013/VC12
 VC140 = 1900  # VC2015/VC14
 VC141 = 1910  # VC2017/VC15
+VC160 = 1920  # VS2019/VC16
 
 def _IsSupportedOmaha2Version(omaha_version):
   """Returns true if omaha_version is an Omaha 2 version and is supported."""

--- a/omaha/precompile/precompile.h
+++ b/omaha/precompile/precompile.h
@@ -32,14 +32,15 @@
 
 // Suppress warning "C5031: #pragma warning(pop): likely mismatch, popping
 // warning state pushed in different file." This works around a problem
-// in winioctl.h introduced with VS 2017 15.9.
-#if (_MSC_VER == 1916)
+// in winioctl.h in the Windows SDK since somewhere between 10.0.15063
+// and 10.0.16399.  See #20584780.
+#if (_MSC_VER >= 1916)
 #pragma warning(push)
 #pragma warning(disable:5031)
 #endif
 #include <winioctl.h>
-#if (_MSC_VER == 1916)
-#pragma warning(pop)
+#if (_MSC_VER >= 1916)
+#pragma warning(pop) // See above; winsdk workaround
 #pragma warning(pop) // #pragma warning(disable:5031)
 #endif
 

--- a/omaha/site_scons/site_tools/atlmfc_vc16_0.py
+++ b/omaha/site_scons/site_tools/atlmfc_vc16_0.py
@@ -1,0 +1,46 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========================================================================
+
+"""Windows ATL MFC for VC16 (Visual Studio 2019) tool for SCons.
+
+Note that ATL MFC requires the commercial (non-free) version of Visual Studio
+2019.
+"""
+
+import os
+
+
+def _FindLocalInstall():
+  """Returns the directory containing the local install of the tool.
+
+  Returns:
+    Path to tool (as a string), or None if not found.
+  """
+  default_dir = os.environ['VCToolsInstallDir'] + 'atlmfc'
+  if os.path.exists(default_dir):
+    return default_dir
+  else:
+    return None
+
+
+def generate(env):
+  # NOTE: SCons requires the use of this name, which fails gpylint.
+  """SCons entry point for this tool."""
+
+  if not env.get('ATLMFC_VC16_0_DIR'):
+    env['ATLMFC_VC16_0_DIR'] = _FindLocalInstall()
+
+  env.AppendENVPath('INCLUDE', env.Dir('$ATLMFC_VC16_0_DIR/include').abspath)
+  env.AppendENVPath('LIB', env.Dir('$ATLMFC_VC16_0_DIR/lib/x86').abspath)

--- a/omaha/site_scons/site_tools/omaha_builders.py
+++ b/omaha/site_scons/site_tools/omaha_builders.py
@@ -411,6 +411,10 @@ def ConfigureEnvFor64Bit(env):
                                    '$ATLMFC_VC14_1_DIR/lib/x64',
                                    platform_sdk_lib_dir + '/um/x64',
                                    platform_sdk_lib_dir + '/ucrt/x64',],
+      omaha_version_utils.VC160: [ '$VC16_0_DIR/lib/x64',
+                                   '$ATLMFC_VC16_0_DIR/lib/x64',
+                                   platform_sdk_lib_dir + '/um/x64',
+                                   platform_sdk_lib_dir + '/ucrt/x64',],
       }[env['msc_ver']]
 
   env.Prepend(LIBPATH=lib_paths)
@@ -421,7 +425,8 @@ def ConfigureEnvFor64Bit(env):
        omaha_version_utils.VC100 : '$VC10_0_DIR/vc/bin/x86_amd64',
        omaha_version_utils.VC120 : '$VC12_0_DIR/vc/bin/x86_amd64',
        omaha_version_utils.VC140 : '$VC14_0_DIR/vc/bin/x86_amd64',
-       omaha_version_utils.VC141 : '$VC14_1_DIR/bin/HostX64/x64'}
+       omaha_version_utils.VC141 : '$VC14_1_DIR/bin/HostX64/x64',
+       omaha_version_utils.VC160 : '$VC16_0_DIR/bin/HostX64/x64'}
       [env['msc_ver']]))
 
   # Filter x86 options that are not supported or conflict with x86-x64 options.

--- a/omaha/site_scons/site_tools/windows_vc16_0.py
+++ b/omaha/site_scons/site_tools/windows_vc16_0.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python2.4
+#
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========================================================================
+
+"""Tool-specific initialization for Visual Studio 2019.
+
+NOTE: This tool is order-dependent, and must be run before
+any other tools that modify the binary, include, or lib paths because it will
+wipe out any existing values for those variables.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+"""
+
+import os
+import SCons
+
+
+def _SetMsvcCompiler(
+    env, vc_flavor='x86'):
+  """When run on a non-Windows system, this function does nothing.
+
+     When run on a Windows system, this function wipes the binary, include
+     and lib paths so that any non-hermetic tools won't be used.
+     These paths will be set up by target_platform_windows and other tools.
+     By wiping the paths here, we make the adding the other tools
+     order-independent.
+  Args:
+    env: The SCons environment in question.
+    vc_flavor: Defaults to x86, can be 'x86', 'amd64' or 'x86_amd64'. The
+        latter is using the 32-bit executable of the 64-bit compiler.
+  Returns:
+    Nothing.
+  Raises:
+    ValueError: An error if vc_flavor is not valid.
+  """
+  if vc_flavor not in ('x86', 'amd64', 'x86_amd64'):
+    raise ValueError('vc_flavor must be one of: amd64, x86, x86_amd64.')
+
+  vc_dir = os.environ.get('VCToolsInstallDir')
+  platform_sdk_dir = os.environ.get('OMAHA_PLATFORM_SDK_DIR')
+  platform_sdk_version = os.environ.get('WindowsSDKVersion')
+  platform_sdk_include_dir = platform_sdk_dir + 'include/' + \
+      platform_sdk_version
+  platform_sdk_lib_dir = platform_sdk_dir + 'lib/' + platform_sdk_version
+
+  env['GOOGLECLIENT'] = '$MAIN_DIR/..'
+  env['THIRD_PARTY'] = '$GOOGLECLIENT/third_party/'
+
+  env.Replace(
+      PLATFORM_SDK_DIR=platform_sdk_dir,
+      MSVC_FLAVOR=('amd64', 'x86')[vc_flavor == 'x86'],
+      VC16_0_DIR=vc_dir,
+      WINDOWS_SDK_10_0_DIR=platform_sdk_dir,
+  )
+
+  # Clear any existing paths.
+  env['ENV']['PATH'] = ''
+  env['ENV']['INCLUDE'] = ''
+  env['ENV']['LIB'] = ''
+
+  tools_paths = []
+  include_paths = []
+  lib_paths = []
+  vc_bin_dir = vc_dir + 'bin/HostX86'
+  if vc_flavor == 'amd64':
+    vc_bin_dir += '/x64'
+  elif vc_flavor == 'x86':
+    vc_bin_dir += '/x86'
+
+  tools_paths += [vc_bin_dir,]
+
+  include_paths.append(vc_dir + '/include')
+  if vc_flavor == 'x86':
+    lib_paths.append(vc_dir + '/lib/x86')
+  else:
+    lib_paths.append(vc_dir + '/lib/x64')
+
+  # Add explicit location of platform SDK to tools path
+  tools_paths.append(platform_sdk_dir + '/bin')
+  include_paths += [
+      platform_sdk_include_dir + 'um',      # Windows SDKs
+      platform_sdk_include_dir + 'shared',  # Windows SDKs
+      platform_sdk_include_dir + 'ucrt',    # Windows CRT
+  ]
+  if vc_flavor == 'x86':
+    lib_paths += [
+        platform_sdk_lib_dir + 'um/x86',    # Windows SDK
+        platform_sdk_lib_dir + 'ucrt/x86',  # Windows CRT
+    ]
+    tools_paths.append(platform_sdk_dir + '/bin/x86')  # VC 12 only
+  else:
+    lib_paths += [
+        platform_sdk_lib_dir + 'um/x64',    # Windows SDK
+        platform_sdk_lib_dir + 'ucrt/x64',  # Windows CRT
+    ]
+
+  for p in tools_paths:
+    env.AppendENVPath('PATH', env.Dir(p).abspath)
+  for p in include_paths:
+    env.AppendENVPath('INCLUDE', env.Dir(p).abspath)
+  for p in lib_paths:
+    env.AppendENVPath('LIB', env.Dir(p).abspath)
+
+
+def generate(env):
+  _SetMsvcCompiler(
+      env=env, vc_flavor='x86')

--- a/omaha/third_party/smartany/scoped_any.h
+++ b/omaha/third_party/smartany/scoped_any.h
@@ -194,7 +194,7 @@ inline T get( scoped_any<T,close_policy,invalid_value,unique> const & t )
 template<typename T,class close_policy,class invalid_value,int unique>
 inline bool valid( scoped_any<T,close_policy,invalid_value,unique> const & t )
 {
-    return t;
+    return static_cast<bool>(t);
 }
 
 // return wrapped resource and give up ownership


### PR DESCRIPTION
Do not merge!

This may require additional work to sort through necessary prior
commits, like the Scons3 work.

The included new python files in

    omaha/site_scons/site_tools/*_vc16_*.py

are almost entirely derivative of prior versions of those files,
so the copyrights are copied unchanged.

Additional breakpad fixes are necessary, but might be resolved
with more warnings disabled.